### PR TITLE
Manage to migrate track info from homepage to music player

### DIFF
--- a/src/Controller/PlayPageController.php
+++ b/src/Controller/PlayPageController.php
@@ -11,16 +11,16 @@ class PlayPageController extends AbstractTwigController
      */
     public function getSongsForPlayPage(int $id): string
     {
-            $fetchSongsManager = new FetchSongsManager();
-            $song = $fetchSongsManager->selectSongById($id);
-            $fetchSongs = new FetchSongsManager();
-            $artistSongs = $fetchSongs->getsongList($id);
-            $fetchSongsManagerImg = new FetchSongsManager();
-            $rndSongCoverImg = $fetchSongsManagerImg->showImgDir();
+        $fetchSongsManager = new FetchSongsManager();
+        $song = $fetchSongsManager->selectSongById($id);
+        $fetchSongs = new FetchSongsManager();
+        $artistSongs = $fetchSongs->getsongList($id);
+        $fetchSongsManagerImg = new FetchSongsManager();
+        $rndSongCoverImg = $fetchSongsManagerImg->showImgDir();
 
-            return $this->twig->render('/Home/General/playPage.html.twig', [
-                'song' => $song, 'artistSongs' => $artistSongs, 'rndSongCoverImg' => $rndSongCoverImg
-            ]);
+        return $this->twig->render('/Home/General/playPage.html.twig', [
+            'song' => $song, 'artistSongs' => $artistSongs, 'rndSongCoverImg' => $rndSongCoverImg
+        ]);
     }
 
     /**
@@ -42,10 +42,11 @@ class PlayPageController extends AbstractTwigController
         // if no sample is available, redirect toward homepage
         if ($trackURL === '') {
             header('Location: /');
-            die();
         }
-        return $this->twig->render('/Home/General/spotifyPlayPage.html.twig',
+        return $this->twig->render(
+            '/Home/General/spotifyPlayPage.html.twig',
             ['trackURL' => $trackURL, 'trackArtist' => $trackArtist,
-                'trackTitle' => $trackTitle, 'trackImg' => $trackImg]);
+                'trackTitle' => $trackTitle, 'trackImg' => $trackImg]
+        );
     }
 }

--- a/src/Controller/PlayPageController.php
+++ b/src/Controller/PlayPageController.php
@@ -22,4 +22,30 @@ class PlayPageController extends AbstractTwigController
                 'song' => $song, 'artistSongs' => $artistSongs, 'rndSongCoverImg' => $rndSongCoverImg
             ]);
     }
+
+    /**
+     * Once you click on a track to play in the homepage, catch the sample info with "$_GET" to feed the music player
+     *
+     * @return string
+     * @throws \Twig\Error\LoaderError
+     * @throws \Twig\Error\RuntimeError
+     * @throws \Twig\Error\SyntaxError
+     */
+    public function playSpotifySong()
+    {
+        // get the music sample from the homepage (then from SPOTIFY)
+        $trackURL = $_GET['spotify-sample'];
+        $trackArtist = $_GET['spotify-artist'];
+        $trackTitle = $_GET['spotify-title'];
+        $trackImg = $_GET['spotify-img'];
+
+        // if no sample is available, redirect toward homepage
+        if ($trackURL === '') {
+            header('Location: /');
+            die();
+        }
+        return $this->twig->render('/Home/General/spotifyPlayPage.html.twig',
+            ['trackURL' => $trackURL, 'trackArtist' => $trackArtist,
+                'trackTitle' => $trackTitle, 'trackImg' => $trackImg]);
+    }
 }

--- a/src/View/Home/General/spotifyPlayPage.html.twig
+++ b/src/View/Home/General/spotifyPlayPage.html.twig
@@ -1,0 +1,40 @@
+{% extends 'layout.html.twig' %}
+
+{% block title %}Wildify | Playing: {{ trackTitle }}{% endblock %}
+
+{# -- content for main-block in main layout -- #}
+{% block content %}
+
+<div class="play-page-container">
+
+    <div class="play-Flex">
+
+        <div class="play-main-info">
+
+            <div class="play-songCover" style="background-image: url('{{ trackImg }}');background-size: cover">
+
+            </div>
+            <div class="play-songInfo">
+                <div class="play-songTitle">
+                    {{ trackTitle }}
+                </div>
+                <div class="play-songArtist">
+                    {{ trackArtist }}
+                </div>
+            </div>
+
+            <a href="#"><img src="/assets/images/playPage/icon-heart-empty.png"
+                             class="add-to-playlist-icon playlist-like-icons"></a>
+
+        </div>
+
+        <div class="playControls-footer">
+            <audio controls autoplay>
+                <source src="{{ trackURL }}" type="audio/mpeg">
+            </audio>
+        </div>
+
+    </div>
+
+    {% endblock %}
+

--- a/src/View/Home/index.html.twig
+++ b/src/View/Home/index.html.twig
@@ -1,5 +1,7 @@
 {% extends 'layout.html.twig' %}
 
+{% block title %}Wildify | Home{% endblock %}
+
 {% block content %}
     <div class="homepage-wrapper">
         {# pop #}
@@ -9,7 +11,13 @@
                 {% for track in pop.tracks %}
                     <div class="single-item-wrapper">
                         <div class="img-and-icon">
-                            <a href="#"><img src="{{ track.album.images[1].url }}" alt="" class="item-img"></a>
+                            <a href="spotify-play?
+                            spotify-sample={{ track.preview_url }}&
+                            spotify-artist={{ track.artists[0].name }}&
+                            spotify-title={{ track.name }}&
+                            spotify-img={{ track.album.images[1].url }}">
+                                <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            </a>
                             <img src="assets/images/play-icon-gold.png" class="play-icon">
                         </div>
                         <p class="item-artist">{{ track.artists[0].name }}</p>
@@ -26,7 +34,13 @@
                 {% for track in rock.tracks %}
                     <div class="single-item-wrapper">
                         <div class="img-and-icon">
-                            <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            <a href="spotify-play?
+                            spotify-sample={{ track.preview_url }}&
+                            spotify-artist={{ track.artists[0].name }}&
+                            spotify-title={{ track.name }}&
+                            spotify-img={{ track.album.images[1].url }}">
+                                <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            </a>
                             <img src="assets/images/play-icon-gold.png" class="play-icon">
                         </div>
                         <p class="item-artist">{{ track.artists[0].name }}</p>
@@ -43,7 +57,13 @@
                 {% for track in metal.tracks %}
                     <div class="single-item-wrapper">
                         <div class="img-and-icon">
-                            <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            <a href="spotify-play?
+                            spotify-sample={{ track.preview_url }}&
+                            spotify-artist={{ track.artists[0].name }}&
+                            spotify-title={{ track.name }}&
+                            spotify-img={{ track.album.images[1].url }}">
+                                <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            </a>
                             <img src="assets/images/play-icon-gold.png" class="play-icon">
                         </div>
                         <p class="item-artist">{{ track.artists[0].name }}</p>
@@ -60,7 +80,13 @@
                 {% for track in electro.tracks %}
                     <div class="single-item-wrapper">
                         <div class="img-and-icon">
-                            <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            <a href="spotify-play?
+                            spotify-sample={{ track.preview_url }}&
+                            spotify-artist={{ track.artists[0].name }}&
+                            spotify-title={{ track.name }}&
+                            spotify-img={{ track.album.images[1].url }}">
+                                <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            </a>
                             <img src="assets/images/play-icon-gold.png" class="play-icon">
                         </div>
                         <p class="item-artist">{{ track.artists[0].name }}</p>
@@ -78,7 +104,13 @@
                 {% for track in country.tracks %}
                     <div class="single-item-wrapper">
                         <div class="img-and-icon">
-                            <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            <a href="spotify-play?
+                            spotify-sample={{ track.preview_url }}&
+                            spotify-artist={{ track.artists[0].name }}&
+                            spotify-title={{ track.name }}&
+                            spotify-img={{ track.album.images[1].url }}">
+                                <img src="{{ track.album.images[1].url }}" alt="" class="item-img">
+                            </a>
                             <img src="assets/images/play-icon-gold.png" class="play-icon">
                         </div>
                         <p class="item-artist">{{ track.artists[0].name }}</p>

--- a/src/routes.php
+++ b/src/routes.php
@@ -11,6 +11,7 @@ return [
     '' => ['HomeController', 'index',],
     'searchSong' => ['SearchPageController', 'searchSongs',],
     'play' => ['PlayPageController', 'getSongsForPlayPage', ['id']],
+    'spotify-play' => ['PlayPageController', 'playSpotifySong',],
     'logout' => ['HomeController', 'logout'],
     /* ------------------------------------------ Setting page USER --------------------------------------------*/
     'setting/profile' => ['UserController', 'showOneUser', ['id']],


### PR DESCRIPTION
Now it is possible to click on a song to play it when you are on the homepage.
/ ! \ - Some of the tracks don't have a spotify preview sample, so in that particular case, on a click, nothing will happen (we are redirected to the homepage, in reality, so we stay where we already are).