### PR TITLE
Manage to add Spotify search on top of local search

### DIFF
--- a/public/assets/css/General/searchPage.css
+++ b/public/assets/css/General/searchPage.css
@@ -10,9 +10,16 @@
     color: var(--colorMainFont);
 }
 
+.search-sub-title {
+    color: var(--colorMainFont);
+    font-family: var(--mainFont);
+    width: 100%;
+    text-align: center;
+}
+
 #noResults{
     font-family: var(--mainFont);
-    color: var(--colorSubFont);
+    color: var(--colorSubDiscFont);
 }
 
 .searchResultsBlock{

--- a/src/Controller/SearchPageController.php
+++ b/src/Controller/SearchPageController.php
@@ -12,13 +12,22 @@ class SearchPageController extends AbstractTwigController
     public function searchSongs()
     {
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+
+            // search on SPOTIFY (keyword "track" is important, instead "song" will be invalid)
+            $songTitleFoSpotify = $_POST['search'];
+            $spotifySearch = new SpotifyAPIController();
+            $spotifySearch->connectToAPI();
+            $spotifySongList = $spotifySearch->searchTracks($songTitleFoSpotify, 'track');
+            $spotifySongList = $spotifySongList->tracks->items;
+
+            // do a LOCAL search
             $fetchSongsManager = new FetchSongsManager();
             $songs = $fetchSongsManager->songSearch();
             $fetchSongsManagerImg = new FetchSongsManager();
             $rndSongCoverImg = $fetchSongsManagerImg->showImgDir();
 
             return $this->twig->render('/Home/General/searchPage.html.twig', [
-                'songs' => $songs, 'rndSongCoverImg' => $rndSongCoverImg
+                'songs' => $songs, 'rndSongCoverImg' => $rndSongCoverImg, 'spotifySongList' => $spotifySongList
             ]);
         }
     }

--- a/src/Controller/SpotifyAPIController.php
+++ b/src/Controller/SpotifyAPIController.php
@@ -151,7 +151,7 @@ class SpotifyAPIController
      * @param $type
      * @return array|object
      */
-    public function searchTracks($search, $type)
+    public function searchTracks($search, $type): array|object
     {
         // On récupère le token dans notre variable session.
         // Il est possible de le stocker dans une BDD, sinon.

--- a/src/View/Home/General/searchPage.html.twig
+++ b/src/View/Home/General/searchPage.html.twig
@@ -1,58 +1,106 @@
-{% extends 'Layout.html.twig' %}
+{% extends 'layout.html.twig' %}
 
 {% block title %} Wildify | Search results{% endblock %}
 
 {# -- content for main-black in main layout -- #}
 {% block content %}
 
-<div class="searchBlock" onload="randombg()">
-		<div class="searchTitle">
-			<h2>Search results</h2>
-		</div>
+    <div class="searchBlock" onload="randombg()">
+        <div class="searchTitle">
+            <h2>Search results</h2>
+        </div>
 
-		<div class="searchResultsBlock">
+        <div class="searchResultsBlock">
 
-			{# ----- Loop for each song --------------------------------- #}
-			{% for song in songs %}
+            {# ----- Loop for each song [LOCAL search] --------------------------------- #}
+            <h3 class="search-sub-title">On Wildify:</h3>
+            {% for song in songs %}
 
-				<a href="/play?id={{ song.ID_song }}" class="song-link">
-					<div class="songCard">
-						<div class="songCardFlex">
+                <a href="/play?id={{ song.ID_song }}" class="song-link">
+                    <div class="songCard">
+                        <div class="songCardFlex">
 
-						{# ---- if song has album cover, show image cover. If not choose random image ---- #}
-						{% if song.image_url %}
-							<div class="songCover" style="background-image: url('/{{song.image_url}}');background-size: cover">
-						{% else %}
-							{% set imgCover = random(rndSongCoverImg) %}
-							<div class="songCover" style="background-image: url('/{{imgCover}}');background-size: cover">
-						{% endif %}
+                            {# ---- if song has album cover, show image cover. If not choose random image ---- #}
+                            {% if song.image_url %}
+                            <div class="songCover"
+                                 style="background-image: url('/{{ song.image_url }}');background-size: cover">
+                                {% else %}
+                                {% set imgCover = random(rndSongCoverImg) %}
+                                <div class="songCover"
+                                     style="background-image: url('/{{ imgCover }}');background-size: cover">
+                                    {% endif %}
 
-							<img src="/assets/images/searchPage/play-icon-gold.png" class="play-icon">
-							</div>
+                                    <img src="/assets/images/searchPage/play-icon-gold.png" class="play-icon">
+                                </div>
 
-							<div class="songInfo">
-								<div class="songTitle"> 
-									{{ song.title }}
-								</div>
-								<div class="songArtist">
-									{{ song.artist }}
-								</div>
-								<div class="songGenre">
-									Genre:
-									{{ song.genre }}
-								</div>
-							</div>
-							
-						</div>
-					</div>
-				</a>
+                                <div class="songInfo">
+                                    <div class="songTitle">
+                                        {{ song.title }}
+                                    </div>
+                                    <div class="songArtist">
+                                        {{ song.artist }}
+                                    </div>
+                                    <div class="songGenre">
+                                        Genre:
+                                        {{ song.genre }}
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </a>
 
-			{# --------- if no results found -------- #}
-			{% else %}
-				<h3 id="noResults">No results found</h3>
-			{% endfor %}
-		</div>
-	</div>
+                {# --------- if no results found -------- #}
+            {% else %}
+                <div>
+                    <h3 id="noResults">Sorry! No results found...</h3>
+                </div>
+            {% endfor %}
+        </div>
+
+        <div class="searchResultsBlock">
+            {# ----- Loop for each song [SPOTIFY search] --------------------------------- #}
+            <h3 class="search-sub-title">On the web:</h3>
+            {% for track in spotifySongList %}
+
+                <a href="spotify-play?
+                            spotify-sample={{ track.preview_url }}&
+                            spotify-artist={{ track.artists[0].name }}&
+                            spotify-title={{ track.name }}&
+                            spotify-img={{ track.album.images[1].url }}">
+                    <div class="songCard">
+                        <div class="songCardFlex">
+
+                            <div class="songCover"
+                                 style="background-image: url('{{ track.album.images[1].url }}');background-size: cover">
+
+                                <img src="/assets/images/searchPage/play-icon-gold.png" class="play-icon">
+                            </div>
+
+                            <div class="songInfo">
+                                <div class="songTitle">
+                                    {{ track.name }}
+                                </div>
+                                <div class="songArtist">
+                                    {{ track.artists[0].name }}
+                                </div>
+                                <div class="songGenre">
+                                    Album
+                                    {{ track.album.name }}
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </a>
+
+                {# --------- if no results found -------- #}
+            {% else %}
+                <div>
+                    <h3 id="noResults">Sorry! No results found...</h3>
+                </div>
+            {% endfor %}
+        </div>
+    </div>
 
 {% endblock %}
 

--- a/src/View/Home/General/searchPage.html.twig
+++ b/src/View/Home/General/searchPage.html.twig
@@ -62,37 +62,37 @@
             {# ----- Loop for each song [SPOTIFY search] --------------------------------- #}
             <h3 class="search-sub-title">On the web:</h3>
             {% for track in spotifySongList %}
-
-                <a href="spotify-play?
+                {% if track.preview_url != '' %}
+                    <a href="spotify-play?
                             spotify-sample={{ track.preview_url }}&
                             spotify-artist={{ track.artists[0].name }}&
                             spotify-title={{ track.name }}&
                             spotify-img={{ track.album.images[1].url }}">
-                    <div class="songCard">
-                        <div class="songCardFlex">
+                        <div class="songCard">
+                            <div class="songCardFlex">
 
-                            <div class="songCover"
-                                 style="background-image: url('{{ track.album.images[1].url }}');background-size: cover">
+                                <div class="songCover"
+                                     style="background-image: url('{{ track.album.images[1].url }}');background-size: cover">
 
-                                <img src="/assets/images/searchPage/play-icon-gold.png" class="play-icon">
-                            </div>
-
-                            <div class="songInfo">
-                                <div class="songTitle">
-                                    {{ track.name }}
+                                    <img src="/assets/images/searchPage/play-icon-gold.png" class="play-icon">
                                 </div>
-                                <div class="songArtist">
-                                    {{ track.artists[0].name }}
-                                </div>
-                                <div class="songGenre">
-                                    Album
-                                    {{ track.album.name }}
+
+                                <div class="songInfo">
+                                    <div class="songTitle">
+                                        {{ track.name }}
+                                    </div>
+                                    <div class="songArtist">
+                                        {{ track.artists[0].name }}
+                                    </div>
+                                    <div class="songGenre">
+                                        Album
+                                        {{ track.album.name }}
+                                    </div>
                                 </div>
                             </div>
                         </div>
-                    </div>
-                </a>
-
+                    </a>
+                {% endif %}
                 {# --------- if no results found -------- #}
             {% else %}
                 <div>


### PR DESCRIPTION
Now we can search a song on Spotify and display the results on top of the local search.
We need to wait for the "spotify-playpage" to check the links between the new page and the second one.